### PR TITLE
fix(nextjs): relax hardhat smart-account quotas and add debug logs

### DIFF
--- a/packages/nextjs/.env.example
+++ b/packages/nextjs/.env.example
@@ -25,12 +25,16 @@ NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=
 # Smart account + gas sponsorship (optional)
 # Enable account abstraction mode in the frontend
 NEXT_PUBLIC_ENABLE_SMART_ACCOUNTS=false
+# Enable verbose smart-account logs in the browser and relay for local debugging
+NEXT_PUBLIC_SMART_ACCOUNT_DEBUG=false
 # Enable playback session keys to avoid wallet signature on each play (requires smart accounts enabled)
 NEXT_PUBLIC_ENABLE_PLAYBACK_SESSIONS=false
 # Deployed Wave3SmartAccountFactory address (if empty, frontend will try deployedContracts.ts)
 NEXT_PUBLIC_SMART_ACCOUNT_FACTORY_ADDRESS=
 # Relayer private key used by /api/smart-account/relay (server-only, do NOT prefix with NEXT_PUBLIC in real deployments)
 SMART_ACCOUNT_RELAYER_PRIVATE_KEY=
+# Optional: server-side relay debug logs (NEXT_PUBLIC_SMART_ACCOUNT_DEBUG also enables them)
+SMART_ACCOUNT_DEBUG=false
 # Optional RPC overrides for relay endpoint
 SMART_ACCOUNT_RPC_URL=
 SMART_ACCOUNT_RPC_URL_HARDHAT=http://127.0.0.1:8545
@@ -38,6 +42,7 @@ SMART_ACCOUNT_RPC_URL_SEPOLIA=
 # Optional: allow Wavecoin.mint sponsorship outside hardhat (default false)
 SMART_ACCOUNT_ALLOW_WAVECOIN_MINT=false
 # Daily sponsorship quotas per owner (set 0 for unlimited)
+# On hardhat, if unset, the relay now defaults to unlimited quotas for easier local development.
 SMART_ACCOUNT_MAX_CREATE_PER_DAY=3
 SMART_ACCOUNT_MAX_EXECUTE_PER_DAY=250
 SMART_ACCOUNT_MAX_AUTHORIZE_SESSION_PER_DAY=20

--- a/packages/nextjs/app/api/smart-account/relay/route.ts
+++ b/packages/nextjs/app/api/smart-account/relay/route.ts
@@ -80,6 +80,17 @@ type QuotaBucket = {
 
 const relayQuotasByOwner = new Map<string, QuotaBucket>();
 
+const isRelayDebugEnabled = () =>
+	process.env.SMART_ACCOUNT_DEBUG === "true" || process.env.NEXT_PUBLIC_SMART_ACCOUNT_DEBUG === "true";
+
+const relayDebug = (event: string, details: Record<string, unknown>) => {
+	if (!isRelayDebugEnabled()) {
+		return;
+	}
+
+	console.info(`[smart-account-relay] ${event}`, details);
+};
+
 type RelayCreateAccountRequest = {
 	action: "createAccount";
 	chainId: number;
@@ -294,9 +305,12 @@ const parseBigIntValue = (value: string): bigint | undefined => {
 
 const nowInSeconds = () => BigInt(Math.floor(Date.now() / 1000));
 
-const getDailyQuotaLimit = (action: RelayAction) => {
+const getDailyQuotaLimit = (chainId: number, action: RelayAction) => {
 	const envValue = process.env[DAILY_QUOTA_ENV[action]];
 	if (!envValue || envValue.trim() === "") {
+		if (chainId === hardhat.id) {
+			return 0;
+		}
 		return DEFAULT_DAILY_QUOTAS[action];
 	}
 
@@ -309,7 +323,7 @@ const getDailyQuotaLimit = (action: RelayAction) => {
 };
 
 const consumeDailyQuota = ({ chainId, owner, action }: { chainId: number; owner: Address; action: RelayAction }) => {
-	const limit = getDailyQuotaLimit(action);
+	const limit = getDailyQuotaLimit(chainId, action);
 	if (limit <= 0) {
 		return true;
 	}
@@ -436,7 +450,21 @@ export async function POST(req: NextRequest) {
 				args: [owner]
 			});
 
+			relayDebug("create-account-check", {
+				chainId,
+				owner,
+				factoryAddress,
+				existingAccount,
+				quotaLimit: getDailyQuotaLimit(chainId, "createAccount")
+			});
+
 			if (existingAccount && existingAccount !== zeroAddress) {
+				relayDebug("create-account-skip-existing", {
+					chainId,
+					owner,
+					smartAccount: existingAccount
+				});
+
 				return NextResponse.json({
 					smartAccount: existingAccount,
 					created: false
@@ -444,6 +472,11 @@ export async function POST(req: NextRequest) {
 			}
 
 			if (!consumeDailyQuota({ chainId, owner, action: "createAccount" })) {
+				relayDebug("create-account-quota-exceeded", {
+					chainId,
+					owner
+				});
+
 				return NextResponse.json({ error: "Daily createAccount sponsorship quota exceeded" }, { status: 429 });
 			}
 
@@ -471,6 +504,13 @@ export async function POST(req: NextRequest) {
 			if (!smartAccount || smartAccount === zeroAddress) {
 				throw new Error("Smart account creation failed");
 			}
+
+			relayDebug("create-account-created", {
+				chainId,
+				owner,
+				smartAccount,
+				txHash
+			});
 
 			return NextResponse.json({
 				txHash,

--- a/packages/nextjs/services/web3/smartAccount.ts
+++ b/packages/nextjs/services/web3/smartAccount.ts
@@ -160,6 +160,16 @@ const SMART_ACCOUNT_FACTORY_DOMAIN = {
 	version: "1"
 } as const;
 
+const isSmartAccountDebugEnabled = () => process.env.NEXT_PUBLIC_SMART_ACCOUNT_DEBUG === "true";
+
+const smartAccountDebug = (event: string, details: Record<string, unknown>) => {
+	if (!isSmartAccountDebugEnabled()) {
+		return;
+	}
+
+	console.info(`[smart-account] ${event}`, details);
+};
+
 type RelayCreateResponse = {
 	txHash: Hash;
 	smartAccount: Address;
@@ -225,6 +235,7 @@ export const getSmartAccountAddress = async ({
 }): Promise<Address | undefined> => {
 	const factoryAddress = getSmartAccountFactoryAddress(chainId);
 	if (!factoryAddress) {
+		smartAccountDebug("factory-missing", { chainId, owner });
 		return undefined;
 	}
 
@@ -233,6 +244,13 @@ export const getSmartAccountAddress = async ({
 		abi: WAVE3_SMART_ACCOUNT_FACTORY_ABI,
 		functionName: "getAccount",
 		args: [owner]
+	});
+
+	smartAccountDebug("get-account", {
+		chainId,
+		owner,
+		factoryAddress,
+		account
 	});
 
 	if (account === zeroAddress) {
@@ -293,16 +311,34 @@ export const ensureSmartAccount = async ({
 		throw new Error("Wave3SmartAccountFactory address is not configured");
 	}
 
+	smartAccountDebug("ensure-start", {
+		chainId,
+		owner,
+		factoryAddress
+	});
+
 	const existingAccount = await getSmartAccountAddress({
 		publicClient,
 		chainId,
 		owner
 	});
 	if (existingAccount) {
+		smartAccountDebug("ensure-existing-account", {
+			chainId,
+			owner,
+			smartAccount: existingAccount
+		});
 		return existingAccount;
 	}
 
 	const deadline = BigInt(Math.floor(Date.now() / 1000) + 60 * 10);
+	smartAccountDebug("ensure-create-account", {
+		chainId,
+		owner,
+		factoryAddress,
+		deadline: deadline.toString()
+	});
+
 	const signature = await walletClient.signTypedData({
 		account: owner,
 		domain: {
@@ -329,6 +365,13 @@ export const ensureSmartAccount = async ({
 	if (!created.smartAccount || !isAddress(created.smartAccount)) {
 		throw new Error("Failed to create smart account");
 	}
+
+	smartAccountDebug("ensure-created-account", {
+		chainId,
+		owner,
+		smartAccount: created.smartAccount,
+		txHash: created.txHash
+	});
 
 	return getAddress(created.smartAccount);
 };


### PR DESCRIPTION
Ajusta el flujo de smart accounts en desarrollo local para evitar el error de quota al crear cuentas repetidamente y agrega logs de debug para diagnosticar cuándo no se detecta una smart account existente.

Cambios

- hardhat usa quota ilimitada por default para createAccount
- se agregan logs de debug en frontend y relay para el flujo de smart account